### PR TITLE
Update for issue with testHashMethodNeedsToBeInComparingProtocol

### DIFF
--- a/src/Geometry-Tests/GEllipseTest.class.st
+++ b/src/Geometry-Tests/GEllipseTest.class.st
@@ -37,26 +37,9 @@ GEllipseTest >> testBoundaryContains [
 
 { #category : #tests }
 GEllipseTest >> testEmpty [
-	| shape line intersections |
-	shape := GEllipse center: 0@0 vertex: 0@0 coVertex: 0@0.
-	line := GLine through: shape center and: 10@10.
-	intersections := self sortedIntersectionsBetween: shape and: line.
-	
-	self assert: intersections isNotEmpty.
-	self assert: (intersections first asPoint closeTo: 0@0).
-	
-	"horizontal line "
-	line := GLine through: 10@20 and: 20@10.
-	intersections := self sortedIntersectionsBetween: shape and: line.
-	self assert: intersections isEmpty.
-	
-	"vertical line"
-	"intersectionsWithVerticalLine: 
-	does not work with an empty ellipse"
-	shape := GEllipse center: 0@0 vertex: 9@0 coVertex: 0@9.
-	line := GLine through: 10@10 and: 10@20.
-	intersections := self sortedIntersectionsBetween: shape and: line.
-	self assert: intersections isEmpty.
+	self should: [ GEllipse center: 0,0 vertex: 0,0 coVertex: 0,0. ] raise: Error.
+	self should: [ GEllipse center: 10,10 vertex: 10,10 coVertex: 10,10. ] raise: Error.
+	self should: [ GEllipse center: 0,0 vertex: 0,0 coVertex: 0,3. ] raise: Error.
 ]
 
 { #category : #tests }

--- a/src/Geometry-Tests/GEllipseTest.class.st
+++ b/src/Geometry-Tests/GEllipseTest.class.st
@@ -12,6 +12,12 @@ GEllipseTest >> actualClass [
 	^ GEllipse
 ]
 
+{ #category : #util }
+GEllipseTest >> sortedIntersectionsBetween: shape and: line [
+	^ (shape intersectionsWith: line) asOrderedCollection 
+		sorted: [ :a :b | a asPoint < b asPoint ].
+]
+
 { #category : #tests }
 GEllipseTest >> testArea [
 	ellipse := GEllipse center: 5 , -1 vertex: 10 , -1 coVertex: 5 , 2.
@@ -27,6 +33,30 @@ GEllipseTest >> testBoundaryContains [
 	self deny: (ellipse boundaryContains: 3, 1).
 	self deny: (ellipse boundaryContains: 2.1, 0.1).
 	self deny: (ellipse boundaryContains: 3, 0.13).
+]
+
+{ #category : #tests }
+GEllipseTest >> testEmpty [
+	| shape line intersections |
+	shape := GEllipse center: 0@0 vertex: 0@0 coVertex: 0@0.
+	line := GLine through: shape center and: 10@10.
+	intersections := self sortedIntersectionsBetween: shape and: line.
+	
+	self assert: intersections isNotEmpty.
+	self assert: (intersections first asPoint closeTo: 0@0).
+	
+	"horizontal line "
+	line := GLine through: 10@20 and: 20@10.
+	intersections := self sortedIntersectionsBetween: shape and: line.
+	self assert: intersections isEmpty.
+	
+	"vertical line"
+	"intersectionsWithVerticalLine: 
+	does not work with an empty ellipse"
+	shape := GEllipse center: 0@0 vertex: 9@0 coVertex: 0@9.
+	line := GLine through: 10@10 and: 10@20.
+	intersections := self sortedIntersectionsBetween: shape and: line.
+	self assert: intersections isEmpty.
 ]
 
 { #category : #tests }
@@ -208,6 +238,17 @@ GEllipseTest >> testMajorAxis [
 GEllipseTest >> testMinorAxis [
 	ellipse := GEllipse center: 10 , 10 vertex: 7.1715 , 10 coVertex: 10 , 8.
 	self assert: ellipse minorAxis equals: (GSegment with: 10 , 8 with: 10 , 12)
+]
+
+{ #category : #tests }
+GEllipseTest >> testNonEmpty [
+	| shape line intersections |
+	shape := GEllipse center: 0@0 vertex: 0@10 coVertex: 5@10.
+	line := GLine through: shape center and: 10@10.
+	intersections := self sortedIntersectionsBetween: shape and: line.
+	self assert: intersections isNotEmpty.
+	self assert: (intersections first asPoint closeTo: -7.4535599249993@ -7.4535599249993).
+	self assert: (intersections second asPoint closeTo: 7.4535599249993@ 7.4535599249993).
 ]
 
 { #category : #tests }

--- a/src/Geometry/GEllipse.class.st
+++ b/src/Geometry/GEllipse.class.st
@@ -144,7 +144,7 @@ GEllipse >> intersectionsWithLine: aGLine [
 	a := self semiMajorAxisLength.
 	b := self semiMinorAxisLength.
 	
-	(a = b and: [ a = 0 ]) ifTrue: [ ^ {center} asSet ].
+	(a = b and: [ a = 0 ]) ifTrue: [ ^ Set with: center ].
 	m := aGLine a / aGLine b negated.
 	c := aGLine c / aGLine b negated.
 	e := c - k.

--- a/src/Geometry/GEllipse.class.st
+++ b/src/Geometry/GEllipse.class.st
@@ -1,3 +1,13 @@
+"
+I am ellipse I have center and 2 vertices.
+
+Example
+
+```Smalltalk
+""circle radius = 10""
+GEllipse center: 0@0 vertex: 0@10 coVertex: 10@0
+``` 
+"
 Class {
 	#name : #GEllipse,
 	#superclass : #GShape,
@@ -133,6 +143,8 @@ GEllipse >> intersectionsWithLine: aGLine [
 	k := center y.
 	a := self semiMajorAxisLength.
 	b := self semiMinorAxisLength.
+	
+	(a = b and: [ a = 0 ]) ifTrue: [ ^ {center} asSet ].
 	m := aGLine a / aGLine b negated.
 	c := aGLine c / aGLine b negated.
 	e := c - k.
@@ -149,7 +161,6 @@ GEllipse >> intersectionsWithLine: aGLine [
 	sqrtContent := (a2m2 + b2 - t2 - k2 + (2 * tk)).
 	sqrtContent >= 0 ifFalse: [ ^ {  } ]. "No intersections"
 	sqrt := (a2m2 + b2 - t2 - k2 + (2 * tk)) sqrt.
-
 	x1 := (h * b2 - (m * a2 * e) + (ab * sqrt)) / (a2m2 + b2).
 	x2 := (h * b2 - (m * a2 * e) - (ab * sqrt)) / (a2m2 + b2).
 	y1 := (b2 * t + (k * a2m2) + (abm * sqrt)) / (a2m2 + b2).

--- a/src/Geometry/GEllipse.class.st
+++ b/src/Geometry/GEllipse.class.st
@@ -21,6 +21,14 @@ Class {
 
 { #category : #'instance creation' }
 GEllipse class >> center: aGPoint vertex: aGPoint2 coVertex: aGPoint3 [
+	| d1 d2 zero |
+	d1 := aGPoint - aGPoint2.
+	d2 := aGPoint - aGPoint3.
+	zero := GVector x: 0 y: 0."Zero vector"
+	(d1 = zero and: [ d2 = zero ]) ifTrue: [ 
+		self error: 'This is not an ellipse but a point.'  ].
+	(d1 = zero or: [ d2 = zero ]) ifTrue: [ 
+		self error: 'This is not an ellipse but a line.' ].
 	^ self new
 		center: aGPoint;
 		vertex: aGPoint2;
@@ -159,7 +167,7 @@ GEllipse >> intersectionsWithLine: aGLine [
 	tk := t * k.
 	sqrtContent := (a2m2 + b2 - t2 - k2 + (2 * tk)).
 	sqrtContent >= 0 ifFalse: [ ^ {  } ]. "No intersections"
-	(a = b and: [ a = 0 ]) ifTrue: [ ^ Set with: center ].
+	
 	sqrt := (a2m2 + b2 - t2 - k2 + (2 * tk)) sqrt.
 	x1 := (h * b2 - (m * a2 * e) + (ab * sqrt)) / (a2m2 + b2).
 	x2 := (h * b2 - (m * a2 * e) - (ab * sqrt)) / (a2m2 + b2).

--- a/src/Geometry/GEllipse.class.st
+++ b/src/Geometry/GEllipse.class.st
@@ -144,7 +144,6 @@ GEllipse >> intersectionsWithLine: aGLine [
 	a := self semiMajorAxisLength.
 	b := self semiMinorAxisLength.
 	
-	(a = b and: [ a = 0 ]) ifTrue: [ ^ {center} asSet ].
 	m := aGLine a / aGLine b negated.
 	c := aGLine c / aGLine b negated.
 	e := c - k.
@@ -160,6 +159,7 @@ GEllipse >> intersectionsWithLine: aGLine [
 	tk := t * k.
 	sqrtContent := (a2m2 + b2 - t2 - k2 + (2 * tk)).
 	sqrtContent >= 0 ifFalse: [ ^ {  } ]. "No intersections"
+	(a = b and: [ a = 0 ]) ifTrue: [ ^ Set with: center ].
 	sqrt := (a2m2 + b2 - t2 - k2 + (2 * tk)) sqrt.
 	x1 := (h * b2 - (m * a2 * e) + (ab * sqrt)) / (a2m2 + b2).
 	x2 := (h * b2 - (m * a2 * e) - (ab * sqrt)) / (a2m2 + b2).

--- a/src/Geometry/GPoint.class.st
+++ b/src/Geometry/GPoint.class.st
@@ -116,6 +116,11 @@ GPoint >> asGPoint [
 	^ self
 ]
 
+{ #category : #converting }
+GPoint >> asPoint [
+	^ self x @ self y
+]
+
 { #category : #accessing }
 GPoint >> coordinates [
 	^ coordinates

--- a/src/Geometry/GRectangle.class.st
+++ b/src/Geometry/GRectangle.class.st
@@ -28,8 +28,6 @@ GRectangle class >> origin: point1 corner: point2 [
 	or := (point1 x min: point2 x) , (point1 y min: point2 y).
 	cor := (point1 x max: point2 x) , (point1 y max: point2 y).
 	
-	or = cor ifTrue: [ self error: 'This is not a rectangle but a point.' ].
-	
 	^ self vertices: { or . (cor x , or y). cor. (or x , cor y) }
 ]
 

--- a/src/Geometry/GRectangle.class.st
+++ b/src/Geometry/GRectangle.class.st
@@ -28,6 +28,8 @@ GRectangle class >> origin: point1 corner: point2 [
 	or := (point1 x min: point2 x) , (point1 y min: point2 y).
 	cor := (point1 x max: point2 x) , (point1 y max: point2 y).
 	
+	or = cor ifTrue: [ self error: 'This is not a rectangle but a point.' ].
+	
 	^ self vertices: { or . (cor x , or y). cor. (or x , cor y) }
 ]
 

--- a/src/Geometry/GSegment.class.st
+++ b/src/Geometry/GSegment.class.st
@@ -74,7 +74,7 @@ GSegment >> distanceTo: aGPoint [
 	^ self asGLine distanceTo: aGPoint
 ]
 
-{ #category : #initialization }
+{ #category : #comparing }
 GSegment >> hash [
 	^ v1 hash bitXor: v2 hash
 ]

--- a/src/Geometry/ManifestGeometry.class.st
+++ b/src/Geometry/ManifestGeometry.class.st
@@ -1,8 +1,0 @@
-"
-I am a project of Euclidean geometry.
-"
-Class {
-	#name : #ManifestGeometry,
-	#superclass : #PackageManifest,
-	#category : #'Geometry-Manifest'
-}


### PR DESCRIPTION
Update for test ProperMethodCategorizationTest >> #testHashMethodNeedsToBeInComparingProtocol

Because Roassal3 uses last version of geometry