### PR TITLE
issue with very small angles... some float magic.

### DIFF
--- a/src/Geometry-Tests/GAngleTest.class.st
+++ b/src/Geometry-Tests/GAngleTest.class.st
@@ -241,3 +241,12 @@ GAngleTest >> testTan [
 	angle := 0 degrees.
 	self assert: angle tan =~ 0
 ]
+
+{ #category : #tests }
+GAngleTest >> testVerySmallAngle [
+
+	self
+		assert: -2.220446049250313e-16 radians radians
+		equals: -2.220446049250313e-16 radians radians radians radians
+]
+


### PR DESCRIPTION
Just for the context:

This little weird behavior made my PIDController go crazy as it could not make up his mind between a ~360deg angle and ~0deg angle... 
`~0deg / 2 = ~0deg` whereas `~360deg / 2 = ~180deg`.
I don't have a nice solution for it yet...

