### PR TITLE
Renamed radians to rads, fixes conflict with Units

### DIFF
--- a/src/Geometry-Tests/GAngleTest.class.st
+++ b/src/Geometry-Tests/GAngleTest.class.st
@@ -40,7 +40,7 @@ GAngleTest >> testCreation [
 	angle := 90 degrees.
 	self assert: angle equals: (GAngle degrees: 90).
 
-	angle := 1π radians.
+	angle := 1π rads.
 	self assert: angle equals: (GAngle radians: 1π)
 ]
 
@@ -185,9 +185,9 @@ GAngleTest >> testMultiplication [
 ]
 
 { #category : #tests }
-GAngleTest >> testRadianNumber [
+GAngleTest >> testRads [
 	angle := 90 degrees.
-	self assert: angle radianNumber equals: 0.5π
+	self assert: angle rads equals: 0.5π
 ]
 
 { #category : #tests }

--- a/src/Geometry-Tests/GArcTest.class.st
+++ b/src/Geometry-Tests/GArcTest.class.st
@@ -47,9 +47,9 @@ GArcTest >> testEquals [
 	self deny: arc = (GArc center: 6 , 6 origin: 8 , 4 direction: 10 , 11).
 	self deny: arc hash = (GArc center: 6 , 6 origin: 8 , 4 direction: 10 , 11) hash.
 	
-	arc := GArc center: 6 , 6 origin: 8 , 4 angle: 0.5π radians.
-	self assert: arc equals: (GArc center: 6 , 6 origin: 8 , 4 angle: 0.5π radians).
-	self assert: arc hash equals: (GArc center: 6 , 6 origin: 8 , 4 angle: 0.5π radians) hash.
+	arc := GArc center: 6 , 6 origin: 8 , 4 angle: 0.5π rads.
+	self assert: arc equals: (GArc center: 6 , 6 origin: 8 , 4 angle: 0.5π rads).
+	self assert: arc hash equals: (GArc center: 6 , 6 origin: 8 , 4 angle: 0.5π rads) hash.
 ]
 
 { #category : #test }

--- a/src/Geometry-Tests/GLineTest.class.st
+++ b/src/Geometry-Tests/GLineTest.class.st
@@ -17,7 +17,7 @@ GLineTest >> testAngleWith [
 	| line2 |
 	line := GLine through: 0 , 0 and: 5 , 24.
 	line2 := GLine through: 3 , 4 and: 4 , 7.
-	self assert: (line angleWith: line2) equals: -0.11635 radians 
+	self assert: (line angleWith: line2) equals: -0.11635 rads 
 ]
 
 { #category : #tests }

--- a/src/Geometry-Tests/GRayTest.class.st
+++ b/src/Geometry-Tests/GRayTest.class.st
@@ -17,7 +17,7 @@ GRayTest >> testAngleWith [
 	| ray2 |
 	ray := GRay origin: 0 , 0 direction: 5 , 24.
 	ray2 := GRay origin: 3 , 4 direction: 4 , 7.
-	self assert: (ray angleWith: ray2) equals: -0.11635 radians
+	self assert: (ray angleWith: ray2) equals: -0.11635 rads
 ]
 
 { #category : #tests }

--- a/src/Geometry-Tests/GSegmentTest.class.st
+++ b/src/Geometry-Tests/GSegmentTest.class.st
@@ -17,7 +17,7 @@ GSegmentTest >> testAngleWith [
 	| segment2 |
 	segment := GSegment with: 0 , 0 with: 5 , 24.
 	segment2 := GSegment with: 3 , 4 with: 4 , 7.
-	self assert: (segment angleWith: segment2) equals: -0.11635 radians
+	self assert: (segment angleWith: segment2) equals: -0.11635 rads
 ]
 
 { #category : #tests }

--- a/src/Geometry-Tests/GVectorTest.class.st
+++ b/src/Geometry-Tests/GVectorTest.class.st
@@ -31,12 +31,12 @@ GVectorTest >> test2DVector [
 GVectorTest >> testAngleWith [
 	vector := {2 . 0} asGVector.
 	self assert: (vector angleWith: vector) isZero.
-	self assert: (vector angleWith: {2 . 1} asGVector) equals: 0.4636476090008063 radians.
-	self assert: ({2 . 1} asGVector angleWith: vector) equals: -0.4636476090008063 radians.
-	self assert: (vector angleWith: {2 . 2} asGVector) equals: 0.7853981633974483 radians.
-	self assert: ({2 . 2} asGVector angleWith: vector) equals: -0.7853981633974483 radians.
-	self assert: (vector angleWith: {1 . 2} asGVector) equals: 1.1071487177940922 radians.
-	self assert: ({1 . 2} asGVector angleWith: vector) equals: -1.1071487177940922 radians
+	self assert: (vector angleWith: {2 . 1} asGVector) equals: 0.4636476090008063 rads.
+	self assert: ({2 . 1} asGVector angleWith: vector) equals: -0.4636476090008063 rads.
+	self assert: (vector angleWith: {2 . 2} asGVector) equals: 0.7853981633974483 rads.
+	self assert: ({2 . 2} asGVector angleWith: vector) equals: -0.7853981633974483 rads.
+	self assert: (vector angleWith: {1 . 2} asGVector) equals: 1.1071487177940922 rads.
+	self assert: ({1 . 2} asGVector angleWith: vector) equals: -1.1071487177940922 rads
 ]
 
 { #category : #tests }
@@ -72,17 +72,17 @@ GVectorTest >> testMultiplication [
 { #category : #tests }
 GVectorTest >> testNonOrientedAngleWith [
 	vector := {2 . 9 . -3} asGVector.
-	self assert: (vector nonOrientedAngleWith: {-3 . -4 . 8} asGVector) equals: 2.37687 radians.
+	self assert: (vector nonOrientedAngleWith: {-3 . -4 . 8} asGVector) equals: 2.37687 rads.
 
 	vector := {5 . 24} asGVector.
-	self assert: (vector nonOrientedAngleWith: {1 . 3} asGVector) equals: 0.11635 radians.
+	self assert: (vector nonOrientedAngleWith: {1 . 3} asGVector) equals: 0.11635 rads.
 
 	vector := {2 . 0} asGVector.
 	self assert: (vector nonOrientedAngleWith: vector) isZero.
-	self assert: (vector nonOrientedAngleWith: {2 . 1} asGVector) equals: 0.4636476090008063 radians.
-	self assert: ({2 . 1} asGVector nonOrientedAngleWith: vector) equals: 0.4636476090008063 radians.
-	self assert: (vector nonOrientedAngleWith: {2 . 2} asGVector) equals: 0.7853981633974483 radians.
-	self assert: ({2 . 2} asGVector nonOrientedAngleWith: vector) equals: 0.7853981633974483 radians.
-	self assert: (vector nonOrientedAngleWith: {1 . 2} asGVector) equals: 1.1071487177940922 radians.
-	self assert: ({1 . 2} asGVector nonOrientedAngleWith: vector) equals: 1.1071487177940922 radians
+	self assert: (vector nonOrientedAngleWith: {2 . 1} asGVector) equals: 0.4636476090008063 rads.
+	self assert: ({2 . 1} asGVector nonOrientedAngleWith: vector) equals: 0.4636476090008063 rads.
+	self assert: (vector nonOrientedAngleWith: {2 . 2} asGVector) equals: 0.7853981633974483 rads.
+	self assert: ({2 . 2} asGVector nonOrientedAngleWith: vector) equals: 0.7853981633974483 rads.
+	self assert: (vector nonOrientedAngleWith: {1 . 2} asGVector) equals: 1.1071487177940922 rads.
+	self assert: ({1 . 2} asGVector nonOrientedAngleWith: vector) equals: 1.1071487177940922 rads
 ]

--- a/src/Geometry/GAngle.class.st
+++ b/src/Geometry/GAngle.class.st
@@ -67,9 +67,9 @@ GAngle class >> degrees: anInteger [
 { #category : #'class initialization' }
 GAngle class >> initialize [
 	TwoPi := 2π.
-	ZeroAngle := 0 radians.
-	RightAngle := 0.5π radians.
-	StraightAngle := 1π radians
+	ZeroAngle := 0 rads.
+	RightAngle := 0.5π rads.
+	StraightAngle := 1π rads
 ]
 
 { #category : #'instance creation' }
@@ -77,6 +77,11 @@ GAngle class >> radians: aNumber [
 	^ self new
 		initializeWith: aNumber;
 		yourself
+]
+
+{ #category : #'instance creation' }
+GAngle class >> rads: aNumber [
+	^ self radians: aNumber
 ]
 
 { #category : #arithmetic }
@@ -101,7 +106,7 @@ GAngle >> / anInteger [
 
 { #category : #comparison }
 GAngle >> < aGAngle [ 
-	^ self radians < aGAngle radians
+	^ self rads < aGAngle rads
 ]
 
 { #category : #comparison }
@@ -116,7 +121,7 @@ GAngle >> = anObject [
 	self == anObject ifTrue: [ ^ true ].
 	self class = anObject class ifFalse: [ ^ false ].
 
-	^ (radians - anObject radians) =~ 0 or: [ (radians - anObject radians) =~ TwoPi ]
+	^ (radians - anObject rads) =~ 0 or: [ (radians - anObject rads) =~ TwoPi ]
 ]
 
 { #category : #comparison }
@@ -137,22 +142,22 @@ GAngle >> adaptToNumber: anInteger andSend: aString [
 
 { #category : #arithmetic }
 GAngle >> addWithAngle: aGAngle [ 
-	^ (self radians + aGAngle radians) radians
+	^ (self rads + aGAngle rads) rads
 ]
 
 { #category : #arithmetic }
 GAngle >> cos [
-	^ self radians cos
+	^ self rads cos
 ]
 
 { #category : #converting }
 GAngle >> degreeNumber [
-	^ self radians radiansToDegrees
+	^ self rads radiansToDegrees
 ]
 
 { #category : #accessing }
 GAngle >> explementary [
-	^ (0 - self radians) radians
+	^ (0 - self rads) rads
 ]
 
 { #category : #comparing }
@@ -171,7 +176,7 @@ GAngle >> initializeWith: aNumber [
 
 { #category : #testing }
 GAngle >> isAcute [
-	^ self > 0 radians and: [ self < RightAngle ]
+	^ self > 0 rads and: [ self < RightAngle ]
 ]
 
 { #category : #testing }
@@ -181,7 +186,7 @@ GAngle >> isObtuse [
 
 { #category : #testing }
 GAngle >> isReflex [
-	^ self > StraightAngle and: [ self radians < TwoPi ]
+	^ self > StraightAngle and: [ self rads < TwoPi ]
 ]
 
 { #category : #testing }
@@ -213,25 +218,38 @@ GAngle >> printOn: aStream [
 
 { #category : #converting }
 GAngle >> radianNumber [
-	^ self radians
+
+	self
+		deprecated: 'Please use #rads instead'
+		transformWith: '`@receiver radianNumber' -> '`@receiver rads'.
+	^ self rads
 ]
 
 { #category : #accessing }
 GAngle >> radians [
+
+	self
+		deprecated: 'Please use #rads instead'
+		transformWith: '`@receiver radians' -> '`@receiver rads'.
+	^ self rads
+]
+
+{ #category : #accessing }
+GAngle >> rads [
 	^ radians
 ]
 
 { #category : #arithmetic }
 GAngle >> sin [
-	^ self radians sin
+	^ self rads sin
 ]
 
 { #category : #arithmetic }
 GAngle >> substractWithAngle: aGAngle [ 
-	^ (aGAngle radians - self radians) radians
+	^ (aGAngle rads - self rads) rads
 ]
 
 { #category : #arithmetic }
 GAngle >> tan [
-	^ self radians tan
+	^ self rads tan
 ]

--- a/src/Geometry/GArc.class.st
+++ b/src/Geometry/GArc.class.st
@@ -151,7 +151,7 @@ GArc >> intersectionsWithLine: aGLine [
 
 { #category : #accessing }
 GArc >> length [
-	^ self angle radians * self radius
+	^ self angle rads * self radius
 ]
 
 { #category : #accessing }

--- a/src/Geometry/GVector.class.st
+++ b/src/Geometry/GVector.class.st
@@ -158,5 +158,5 @@ GVector >> nonOrientedAngleWith: aGVector [
 	^ ([ ((self dotProduct: aGVector) / (self length * aGVector length)) arcCos ]
 		on: DomainError
 		do:
-			[ "Sometimes we can get a Domain Error because of some missprecision of floats... In that case we will reduce the precision to get a result" ((self dotProduct: aGVector) / (self length * aGVector length) roundTo: 0.00000000000001) arcCos ]) radians
+			[ "Sometimes we can get a Domain Error because of some missprecision of floats... In that case we will reduce the precision to get a result" ((self dotProduct: aGVector) / (self length * aGVector length) roundTo: 0.00000000000001) arcCos ]) rads
 ]

--- a/src/Geometry/GZeroVector.class.st
+++ b/src/Geometry/GZeroVector.class.st
@@ -19,7 +19,7 @@ GZeroVector class >> coordinates: aCoordinates [
 
 { #category : #arithmetic }
 GZeroVector >> angleWith: aGVector [
-	^ 0 radians
+	^ 0 rads
 ]
 
 { #category : #testing }

--- a/src/Geometry/Number.extension.st
+++ b/src/Geometry/Number.extension.st
@@ -16,8 +16,9 @@ Number >> degrees [
 ]
 
 { #category : #'*Geometry' }
-Number >> divideWithAngle: aGAngle [ 
-	^ (aGAngle radians / self) radians
+Number >> divideWithAngle: aGAngle [
+
+	^ (aGAngle rads / self) rads
 ]
 
 { #category : #'*Geometry' }
@@ -26,8 +27,9 @@ Number class >> epsilon [
 ]
 
 { #category : #'*Geometry' }
-Number >> multiplyWithAngle: aGAngle [ 
-	^ (aGAngle radians * self) radians
+Number >> multiplyWithAngle: aGAngle [
+
+	^ (aGAngle rads * self) rads
 ]
 
 { #category : #'*Geometry' }
@@ -36,7 +38,7 @@ Number >> multiplyWithVector: aGVector [
 ]
 
 { #category : #'*Geometry' }
-Number >> radians [
+Number >> rads [
 	^ GAngle radians: self
 ]
 


### PR DESCRIPTION
There is a conflict of `Number>>#radians` extension method between Geometry and [Units](https://github.com/zweidenker/Units) libraries: https://github.com/TelescopeSt/Geometry/issues/22

Because [Units](https://github.com/zweidenker/Units) was first to create this extension and uses many alternative names as well (rad, radian, radians), I propose renaming `radians` to `rads` here.

The conflict is only in the `Number` extension, but I renamed `GAngle>>#radians` as well to keep polymorphism working and to keep the names consistent.